### PR TITLE
Adds subject set, role data to projects

### DIFF
--- a/panoptes_cli/scripts/panoptes.py
+++ b/panoptes_cli/scripts/panoptes.py
@@ -10,8 +10,9 @@ def cli():
 @cli.command()
 @click.option('--id', help='Project ID', required=False, type=int)
 @click.option('--display-name')
+@click.option('--sets', is_flag=True)
 @click.argument('slug', required=False)
-def project(id, display_name, slug):
+def project(id, display_name, slug, sets):
     projects = panoptes.get_projects(id, slug=slug, display_name=display_name)
 
     for proj_data in projects['projects']:
@@ -19,6 +20,16 @@ def project(id, display_name, slug):
         click.echo('\tClassification count: %s' % proj_data['classifications_count'])
         click.echo('\tSubject count: %s' % proj_data['subjects_count'])
         click.echo('')
+
+        if sets or verbose:
+            click.echo('Subject sets:')
+
+            subject_sets = map(lambda id: panoptes.get_subject_set(id)['subject_sets'][0], proj_data['links']['subject_sets'])
+
+            for subject_set in subject_sets:
+                click.echo('\t%s: %s' % (subject_set['id'], subject_set['display_name']))
+
+            click.echo('')
 
 @cli.command()
 @click.argument('subject_id', required=True, type=int)

--- a/panoptes_cli/scripts/panoptes.py
+++ b/panoptes_cli/scripts/panoptes.py
@@ -11,8 +11,10 @@ def cli():
 @click.option('--id', help='Project ID', required=False, type=int)
 @click.option('--display-name')
 @click.option('--sets', is_flag=True)
+@click.option('--roles', is_flag=True)
+@click.option('--verbose', '-v', is_flag=True)
 @click.argument('slug', required=False)
-def project(id, display_name, slug, sets):
+def project(id, display_name, slug, sets, roles, verbose):
     projects = panoptes.get_projects(id, slug=slug, display_name=display_name)
 
     for proj_data in projects['projects']:
@@ -27,9 +29,26 @@ def project(id, display_name, slug, sets):
             subject_sets = map(lambda id: panoptes.get_subject_set(id)['subject_sets'][0], proj_data['links']['subject_sets'])
 
             for subject_set in subject_sets:
-                click.echo('\t%s: %s' % (subject_set['id'], subject_set['display_name']))
+                click.echo('\t%(id)s: %(display_name)s' % subject_set)
 
             click.echo('')
+
+        if roles or verbose:
+            click.echo('Roles:')
+
+            def get_collaborator(role_id):
+                role_data = panoptes.get_project_role(role_id)['project_roles'][0]
+                user_data = panoptes.get_user(role_data['links']['owner']['id'])['users'][0]
+                return {
+                    'id': user_data['id'],
+                    'login': user_data['login'],
+                    'roles': ', '.join(role_data['roles']),
+                }
+
+            collaborators = map(get_collaborator, proj_data['links']['project_roles'])
+
+            for collaborator in collaborators:
+                click.echo('\t%(login)s (%(id)s): %(roles)s' % collaborator)
 
 @cli.command()
 @click.argument('subject_id', required=True, type=int)

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -56,3 +56,6 @@ class Panoptes:
 
     def get_subject(self, subject_id):
         return self.get('/subjects/%s' % subject_id)
+
+    def get_subject_set(self, subject_set_id):
+        return self.get('/subject_sets/%s' % subject_set_id)

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -59,3 +59,9 @@ class Panoptes:
 
     def get_subject_set(self, subject_set_id):
         return self.get('/subject_sets/%s' % subject_set_id)
+
+    def get_user(self, user_id):
+        return self.get('/users/%s' % user_id)
+
+    def get_project_role(self, project_role_id):
+        return self.get('/project_roles/%s' % project_role_id)


### PR DESCRIPTION
Shows a list of subject sets and ids when using the `--sets` flag, a list of users linked to a project and their roles when using the `--roles` flag, and `--verbose` (or `-v`) to show everything - basically @mrniaboc's wish list from Slack

![screen shot 2016-01-15 at 14 46 10](https://cloud.githubusercontent.com/assets/2725841/12355751/c82677ba-bb96-11e5-945a-e0f9cdf3d97d.png)
