### PR TITLE
Reuse request sessions

### DIFF
--- a/panoptes_cli/scripts/panoptes.py
+++ b/panoptes_cli/scripts/panoptes.py
@@ -1,12 +1,13 @@
 import click
 from panoptes_client.panoptes import Panoptes
 
-panoptes = Panoptes()
+panoptes = None
 
 @click.group()
-@click.option('--endpoint', default='https://panoptes.zooniverse.org/api')
+@click.option('--endpoint', default='https://panoptes.zooniverse.org/api', type=str)
 def cli(endpoint):
-    panoptes.endpoint = endpoint
+    global panoptes
+    panoptes = Panoptes(endpoint=endpoint)
 
 @cli.command()
 @click.option('--id', help='Project ID', required=False, type=int)

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -11,7 +11,7 @@ class Panoptes:
         'Content-Type': 'application/vnd.api+json; version=1'
     }
 
-    def __init__(self, endpoint='https://panoptes.zooniverse.org/api'):
+    def __init__(self, endpoint):
         self.endpoint = endpoint
         self.session = requests.session()
 

--- a/panoptes_client/panoptes.py
+++ b/panoptes_client/panoptes.py
@@ -13,6 +13,7 @@ class Panoptes:
 
     def __init__(self, endpoint='https://panoptes.zooniverse.org/api'):
         self.endpoint = endpoint
+        self.session = requests.session()
 
     def _headers_for_get(self):
         headers = self._default_headers.copy()
@@ -36,9 +37,8 @@ class Panoptes:
         _headers = self._headers_for_get().copy()
         _headers.update(headers)
         headers = _headers
-
-        r = requests.get(self.endpoint + path, params=params,  headers=headers)
-        return r.json()
+        url = self.endpoint + path
+        return self.session.get(url, params=params,  headers=headers).json()
 
     def get_projects(self, project_id, slug=None, display_name=None):
         if project_id is None:


### PR DESCRIPTION
This adds a sweet speed increase to multiple requests by reusing the requests session. Also, endpoint configuration is all done from the CLI, rather than having a default in two places