### PR TITLE
add a subject_set_upload function for both CLI and python api calls

### DIFF
--- a/panoptes_cli/commands/subject_set.py
+++ b/panoptes_cli/commands/subject_set.py
@@ -164,7 +164,54 @@ def upload_subjects(
 
     Any local files will still be detected and uploaded.
     """
+    subject_set_upload(
+        subject_set_id,
+        manifest_files,
+        allow_missing,
+        remote_location,
+        mime_type
+    )
 
+@subject_set.command(name='add-subjects')
+@click.argument('subject-set-id', required=True, type=int)
+@click.argument('subject-ids', required=True, nargs=-1)
+def add_subjects(subject_set_id, subject_ids):
+    """
+    Links existing subjects to this subject set.
+
+    This command is useful mainly for adding previously uploaded subjects to
+    additional subject sets.
+
+    See the upload-subjects command to create new subjects in a subject set.
+    """
+    s = SubjectSet.find(subject_set_id)
+    s.add(subject_ids)
+
+
+@subject_set.command(name='remove-subjects')
+@click.argument('subject-set-id', required=True, type=int)
+@click.argument('subject-ids', required=True, nargs=-1)
+def remove_subjects(subject_set_id, subject_ids):
+    """
+    Unlinks subjects from this subject set.
+
+    The subjects themselves are not deleted or modified in any way and will
+    still be present in any other sets they're linked to.
+    """
+
+    s = SubjectSet.find(subject_set_id)
+    s.remove(subject_ids)
+
+
+def echo_subject_set(subject_set):
+    click.echo(
+        u'{} {}'.format(
+            subject_set.id,
+            subject_set.display_name
+        )
+    )
+
+def subject_set_upload(subject_set_id,manifest_files,allow_missing,remote_location,mime_type):
     subject_set = SubjectSet.find(subject_set_id)
     subject_rows = []
     for manifest_file in manifest_files:
@@ -230,44 +277,5 @@ def upload_subjects(
         move_created(0)
         link_created(0)
 
-
-@subject_set.command(name='add-subjects')
-@click.argument('subject-set-id', required=True, type=int)
-@click.argument('subject-ids', required=True, nargs=-1)
-def add_subjects(subject_set_id, subject_ids):
-    """
-    Links existing subjects to this subject set.
-
-    This command is useful mainly for adding previously uploaded subjects to
-    additional subject sets.
-
-    See the upload-subjects command to create new subjects in a subject set.
-    """
-    s = SubjectSet.find(subject_set_id)
-    s.add(subject_ids)
-
-
-@subject_set.command(name='remove-subjects')
-@click.argument('subject-set-id', required=True, type=int)
-@click.argument('subject-ids', required=True, nargs=-1)
-def remove_subjects(subject_set_id, subject_ids):
-    """
-    Unlinks subjects from this subject set.
-
-    The subjects themselves are not deleted or modified in any way and will
-    still be present in any other sets they're linked to.
-    """
-
-    s = SubjectSet.find(subject_set_id)
-    s.remove(subject_ids)
-
-
-def echo_subject_set(subject_set):
-    click.echo(
-        u'{} {}'.format(
-            subject_set.id,
-            subject_set.display_name
-        )
-    )
 
 from panoptes_client import Subject


### PR DESCRIPTION
I'd like to use the subject set upload functionality in a python script. And i don't want to shell out or running a subprocess from python. 

This change splits out the upload function and adds a wrapper that the click cli calls. This was it's available for both python use and via the cli. Inspired by https://github.com/pallets/click/issues/40#issuecomment-232347953

Let me know if this is a good idea worth pursuing, happy to make changes as needed. 
