### PR TITLE
Adds a quiet switch for project, subject set creation

### DIFF
--- a/panoptes_cli/commands/project.py
+++ b/panoptes_cli/commands/project.py
@@ -94,7 +94,13 @@ def info(project_id):
     help="Makes the project publically accessible.",
     is_flag=True
 )
-def create(display_name, description, primary_language, public):
+@click.option(
+    '--quiet',
+    '-q',
+    help='Only print project ID (omit name).',
+    is_flag=True,
+)
+def create(display_name, description, primary_language, public, quiet):
     """
     Creates a new project.
 
@@ -107,7 +113,11 @@ def create(display_name, description, primary_language, public):
     project.primary_language = primary_language
     project.private = not public
     project.save()
-    echo_project(project)
+
+    if quiet:
+        click.echo(project.id)
+    else:
+        echo_project(project)
 
 @project.command()
 @click.argument('project-id', required=True, type=int)

--- a/panoptes_cli/commands/subject_set.py
+++ b/panoptes_cli/commands/subject_set.py
@@ -85,9 +85,15 @@ def info(subject_set_id):
 
 
 @subject_set.command()
+@click.option(
+    '--quiet',
+    '-q',
+    help='Only print subject set ID (omit name).',
+    is_flag=True,
+)
 @click.argument('project-id', required=True, type=int)
 @click.argument('display-name', required=True)
-def create(project_id, display_name):
+def create(quiet, project_id, display_name):
     """
     Creates a new subject set.
 
@@ -98,7 +104,11 @@ def create(project_id, display_name):
     subject_set.links.project = project_id
     subject_set.display_name = display_name
     subject_set.save()
-    echo_subject_set(subject_set)
+
+    if quiet:
+        click.echo(subject_set.id)
+    else:
+        echo_subject_set(subject_set)
 
 
 @subject_set.command()


### PR DESCRIPTION
Adds a `-q` / `--quiet` switch for `project create` and `subject-set create`, which will only output the new resource IDs on completion.

Closes #156 