### PR TITLE
Update Panoptes Client to >=1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'Click>=6.7,<7.1',
         'PyYAML>=5.1,<5.4',
-        'panoptes-client>=1.0,<2.0',
+        'panoptes-client>=1.3,<2.0',
         'humanize>=0.5.1,<1.1',
         'pathvalidate>=0.29.0,<0.30',
     ],


### PR DESCRIPTION
Bumping dependency requirement for Panoptes Client to ensure Azure-compatible headers are included in requests.