### PR TITLE
doc changes: march 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ directly from GitHub (though be aware that this may contain
 bugs/untested/incomplete features):
 
 ```
-$ pip install -U git+git://github.com/zooniverse/panoptes-cli.git
+$ pip install -U git+https://github.com/zooniverse/panoptes-cli.git
 ```
 
 To upgrade an existing installation to the latest version:

--- a/README.md
+++ b/README.md
@@ -231,6 +231,12 @@ $ panoptes subject-set upload-subjects 4667 panoptes-upload-4667.yaml
 $ panoptes project download --generate 2797 classifications.csv
 ```
 
+It is also possible to generate and download workflow classification or subject set classification exports
+```
+$ panoptes workflow download-classifications --generate 18706 workflow-18706-classifications.csv
+$ panoptes subject-set download-classifications --generate 79758 subjectset-79759-classifications.csv
+```
+
 ### Generate and download a talk comments export
 
 ```


### PR DESCRIPTION
Doc updates:
1. edit git-based `pip install` command for "latest" version of code to use HTTPS.  this change was prompted by receiving the following error message using old `git+git://` command:
```
  fatal: remote error:
    The unauthenticated git protocol on port 9418 is no longer supported.
  Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

2. add command example for generating data export (including for subject set)