### PR TITLE
Fix #222

### DIFF
--- a/panoptes_cli/commands/subject_set.py
+++ b/panoptes_cli/commands/subject_set.py
@@ -333,18 +333,20 @@ def upload_subjects(
                                 upload_state['file_column'].append(
                                     field_number,
                                 )
-                                if not validate_file(file_path):
+                                if validate_file(file_path):
+                                    files.append(file_path)
+                                elif not upload_state['allow_missing']:
                                     return -1
-                                files.append(file_path)
                     else:
                         for field_number in upload_state['file_column']:
                             file_path = os.path.join(
                                 file_root,
                                 row[field_number - 1]
                             )
-                            if not validate_file(file_path):
+                            if validate_file(file_path):
+                                files.append(file_path)
+                            elif not upload_state['allow_missing']:
                                 return -1
-                            files.append(file_path)
 
                     for field_number, _mime_type in zip(
                         upload_state['remote_location'],


### PR DESCRIPTION
These changes fix issue #222.  The `validate_file` checks for each row were returning early if no file was found regardless of how the `allow_missing` flag was set.  The existing `allow_missing` check was after the early return.

The logic behind checking for a valid file has been updated to ensure the state of `allow_missing` is checked before returning early.

I have tested this locally and it works as intended now, my only concern is the messaging set to stderr in the `validate_file` function might be a bit confusing for anyone using the code with this flag set as it says `Error:` at the start.

I am happy to update the message to be a bit more dynamic and change to a `Warning:` when `allow_missing` is used but was on the fence if the extra logic needed for that was really worth it in this case.