### PR TITLE
Update Docker dev builds for https

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM python:3.9-alpine
 WORKDIR /usr/src/panoptes-cli
 
 RUN apk --no-cache add git libmagic
-RUN pip install git+git://github.com/zooniverse/panoptes-python-client.git
+RUN pip install git+https://github.com/zooniverse/panoptes-python-client.git
 
 COPY . .
 

--- a/Dockerfile.dev2
+++ b/Dockerfile.dev2
@@ -3,7 +3,7 @@ FROM python:2-alpine
 WORKDIR /usr/src/panoptes-cli
 
 RUN apk --no-cache add git libmagic
-RUN pip install git+git://github.com/zooniverse/panoptes-python-client.git
+RUN pip install git+https://github.com/zooniverse/panoptes-python-client.git
 
 COPY . .
 


### PR DESCRIPTION
Docker `dev` (default python3) and `dev2` (python2) builds are failing because `git+git://` based installation fails.  Error message: `The unauthenticated git protocol on port 9418 is no longer supported.`

Updates these to use `git+https://` based install for those two builds.