### PR TITLE
add examples for retire and unretiring subjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,27 @@ $ panoptes subject-set ls -w 1579
 4667 My first subject set
 ```
 
+### Retire subjects in a workflow
+
+```
+# for known subjects with ids 2001, 2001 and workflow with id 101
+$ panoptes workflow retire-subjects 101 2001 2002
+```
+
+### Un-Retire subjects in a workflow
+
+```
+# for known subjects with ids 2001, 2001 and workflow with id 101
+$ panoptes workflow unretire-subjects 101 2001 2002
+```
+
+#### By subject sets, i.e. for all the linked subjects in a subject set
+
+```
+# for known subject sets with ids 300, 301 and workflow with id 101
+panoptes workflow unretire-subject-sets 101 300 301
+```
+
 ### List subject sets in a project
 
 ```


### PR DESCRIPTION
This PR adds examples to the readme for retiring subjects and unretiring subjects for a workflow and is a follow up to #228 based on review comments, https://github.com/zooniverse/panoptes-cli/pull/228#pullrequestreview-991001808

I'll note that a while back it was not desired to overload the readme but rather we ensure the built in CLI help cmds provide enough context to ensure folks can find the behviours they need, https://github.com/zooniverse/panoptes-cli/pull/97#pullrequestreview-205265132