### PR TITLE
Add iNat import command

### DIFF
--- a/panoptes_cli/commands/inaturalist.py
+++ b/panoptes_cli/commands/inaturalist.py
@@ -1,0 +1,33 @@
+import click
+
+from panoptes_cli.scripts.panoptes import cli
+from panoptes_client import Inaturalist
+
+
+@cli.group()
+def inaturalist():
+    """Contains commands related to iNaturalist integration"""
+    pass
+
+@inaturalist.command(name='inat-import')
+@click.option(
+    '--taxon-id',
+    help = (
+        "iNaturalist Taxon ID of the taxa you want to import."
+    ),
+    required = True,
+    type = int,
+)
+@click.option(
+    '--subject-set-id',
+    help=(
+        "ID of the Zooniverse subject set to import into."
+    ),
+    required=True,
+    type=int,
+)
+def import_observations(taxon_id, subject_set_id):
+    """Requests Panoptes begin an iNaturalist subject import."""
+
+    click.echo(f'Importing taxon ID {taxon_id} into subject set {subject_set_id}:')
+    Inaturalist.inat_import(taxon_id, subject_set_id)

--- a/panoptes_cli/commands/inaturalist.py
+++ b/panoptes_cli/commands/inaturalist.py
@@ -32,4 +32,3 @@ def import_observations(taxon_id, subject_set_id):
 
     click.echo(f'Importing taxon ID {taxon_id} into subject set {subject_set_id}.')
     Inaturalist.inat_import(taxon_id, subject_set_id)
-

--- a/panoptes_cli/commands/inaturalist.py
+++ b/panoptes_cli/commands/inaturalist.py
@@ -27,8 +27,15 @@ def inaturalist():
     required=True,
     type=int,
 )
-def import_observations(taxon_id, subject_set_id):
+@click.option(
+    '--updated-since',
+    help=(
+        "Optional: Import observations since this timestamp"
+    ),
+    required=False,
+)
+def import_observations(taxon_id, subject_set_id, updated_since=None):
     """Requests Panoptes begin an iNaturalist subject import."""
 
     click.echo(f'Importing taxon ID {taxon_id} into subject set {subject_set_id}.')
-    Inaturalist.inat_import(taxon_id, subject_set_id)
+    Inaturalist.inat_import(taxon_id, subject_set_id, updated_since)

--- a/panoptes_cli/commands/inaturalist.py
+++ b/panoptes_cli/commands/inaturalist.py
@@ -9,14 +9,15 @@ def inaturalist():
     """Contains commands related to iNaturalist integration"""
     pass
 
-@inaturalist.command(name='inat-import')
+
+@inaturalist.command(name='import-observations')
 @click.option(
     '--taxon-id',
-    help = (
+    help=(
         "iNaturalist Taxon ID of the taxa you want to import."
     ),
-    required = True,
-    type = int,
+    required=True,
+    type=int,
 )
 @click.option(
     '--subject-set-id',
@@ -29,5 +30,6 @@ def inaturalist():
 def import_observations(taxon_id, subject_set_id):
     """Requests Panoptes begin an iNaturalist subject import."""
 
-    click.echo(f'Importing taxon ID {taxon_id} into subject set {subject_set_id}:')
+    click.echo(f'Importing taxon ID {taxon_id} into subject set {subject_set_id}.')
     Inaturalist.inat_import(taxon_id, subject_set_id)
+

--- a/panoptes_cli/scripts/panoptes.py
+++ b/panoptes_cli/scripts/panoptes.py
@@ -55,3 +55,4 @@ from panoptes_cli.commands.subject import *
 from panoptes_cli.commands.subject_set import *
 from panoptes_cli.commands.user import *
 from panoptes_cli.commands.workflow import *
+from panoptes_cli.commands.inaturalist import *


### PR DESCRIPTION
Calls the python client's iNat import methods, which sends the request out to Panoptes. Currently no way to track progress on this outside of waiting for the email. This also will need to wait to merge/release until the python client's corresponding work is released and the client's version updated here.