### PR TITLE
Newest CLI version should require newest client version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     install_requires=[
         'Click>=6.7,<8.2',
         'PyYAML>=5.1,<6.1',
-        'panoptes-client>=1.4,<2.0',
+        'panoptes-client>=1.6,<2.0',
         'humanize>=0.5.1,<4.5',
         'pathvalidate>=0.29.0,<2.6',
     ],


### PR DESCRIPTION
The CLI was recently updated to support the python client's new functionality in client v1.6. The required version of the client in the CLI package should have been bumped at that time. 