### PR TITLE
Removing async saving from subject upload and adding more debug logs

### DIFF
--- a/panoptes_cli/commands/subject_set.py
+++ b/panoptes_cli/commands/subject_set.py
@@ -22,7 +22,7 @@ MAX_UPLOAD_FILE_SIZE = 1024 * 1024
 CURRENT_STATE_VERSION = 1
 
 if os.environ.get("PANOPTES_DEBUG"):
-    logger = logging.getLogger('panoptes_client')
+    logger = logging.getLogger("panoptes_client")
 else:
     logger = None
 

--- a/panoptes_cli/commands/subject_set.py
+++ b/panoptes_cli/commands/subject_set.py
@@ -421,24 +421,25 @@ def upload_subjects(
         label='Uploading subjects',
     ) as _subject_rows:
         try:
-            for subject_row in _subject_rows:
-                if logger is not None:
-                    logger.debug("Starting new subject:")
-                count, (files, metadata) = subject_row
-                subject = Subject()
-                subject.links.project = subject_set.links.project
-                for media_file in files:
-                    subject.add_location(media_file)
-                subject.metadata.update(metadata)
-                subject.save()
+            with Subject.async_saves():
+                for subject_row in _subject_rows:
+                    if logger is not None:
+                        logger.debug("Starting new subject:")
+                    count, (files, metadata) = subject_row
+                    subject = Subject()
+                    subject.links.project = subject_set.links.project
+                    for media_file in files:
+                        subject.add_location(media_file)
+                    subject.metadata.update(metadata)
+                    subject.save()
 
-                if logger is not None:
-                    logger.debug(f"Saved {subject.id}")
+                    if logger is not None:
+                        logger.debug(f"Saved {subject.id}")
 
-                pending_subjects.append((subject, subject_row))
+                    pending_subjects.append((subject, subject_row))
 
-                move_created(MAX_PENDING_SUBJECTS)
-                link_subjects(LINK_BATCH_SIZE)
+                    move_created(MAX_PENDING_SUBJECTS)
+                    link_subjects(LINK_BATCH_SIZE)
 
             move_created(0)
             link_subjects(0)

--- a/panoptes_cli/commands/subject_set.py
+++ b/panoptes_cli/commands/subject_set.py
@@ -408,8 +408,10 @@ def upload_subjects(
     def link_subjects(limit):
         if len(upload_state['waiting_to_link']) > limit:
             if logger is not None:
-                logger.debug(f"Linking {upload_state['waiting_to_link'].keys()} "
-                             f"to {subject_set.id}")
+                logger.debug(
+                    f"Linking {upload_state['waiting_to_link'].keys()} "
+                    f"to {subject_set.id}"
+                )
             subject_set.add(list(upload_state['waiting_to_link'].keys()))
             upload_state['waiting_to_link'].clear()
 

--- a/panoptes_cli/commands/subject_set.py
+++ b/panoptes_cli/commands/subject_set.py
@@ -408,7 +408,8 @@ def upload_subjects(
     def link_subjects(limit):
         if len(upload_state['waiting_to_link']) > limit:
             if logger is not None:
-                logger.debug(f"Linking {upload_state['waiting_to_link'].keys()} to {subject_set.id}")
+                logger.debug(f"Linking {upload_state['waiting_to_link'].keys()} "
+                             f"to {subject_set.id}")
             subject_set.add(list(upload_state['waiting_to_link'].keys()))
             upload_state['waiting_to_link'].clear()
 
@@ -448,7 +449,10 @@ def upload_subjects(
                 or len(upload_state['waiting_to_link']) > 0
             ):
                 if logger is not None:
-                    logger.error(f"Failed! There are {len(pending_subjects)} pending subjects and {len(upload_state['waiting_to_link'])} subjects unlinked!")
+                    logger.error(f"Failed! There are {len(pending_subjects)} "
+                                 "pending subjects and "
+                                 f"{len(upload_state['waiting_to_link'])} "
+                                 "subjects unlinked!")
                 click.echo('Error: Upload failed.', err=True)
                 if click.confirm(
                     'Would you like to save the upload state to resume the '

--- a/panoptes_cli/commands/subject_set.py
+++ b/panoptes_cli/commands/subject_set.py
@@ -397,7 +397,7 @@ def upload_subjects(
     def move_created(limit):
         while len(pending_subjects) > limit:
             for subject, subject_row in pending_subjects:
-                if subject._save_result:
+                if subject.async_save_result:
                     if logger is not None:
                         logger.debug(f"Moving {subject}")
                     pending_subjects.remove((subject, subject_row))


### PR DESCRIPTION
I removed the asynchronous saving call for subject upload since it seemed to be leading to soft crashes ([see relevant panoptes client PR](https://github.com/zooniverse/panoptes-python-client/pull/298)). Also added more debug logs using the same `panoptes_client` logger which is defined when setting the environment variable `PANOPTES_DEBUG=True`.